### PR TITLE
feat: support per-route middlewares

### DIFF
--- a/src/core/schema-types.ts
+++ b/src/core/schema-types.ts
@@ -51,6 +51,8 @@ export interface TypeSafeRouteConfig<TQuery = any, TParams = any, TBody = any, T
   strict?: boolean;
   /** Per-route response validation override - validates response against schema */
   validateResponse?: boolean;
+  /** Optional Restana middlewares to be executed before validation */
+  middlewares?: restana.RequestHandler<restana.Protocol.HTTP>[];
   handler: TypeSafeRouteHandler<TQuery, TParams, TBody, TResponse>;
 }
 

--- a/src/core/typed-app.ts
+++ b/src/core/typed-app.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { $ZodIssue } from '@zod/core';
-import { Protocol, Service, Request, Response } from 'restana';
+import { Protocol, Service, Request, Response, RequestHandler } from 'restana';
 
 import { TypeSafeApp, TypeSafeRouteConfig } from './schema-types';
 
@@ -46,6 +46,8 @@ export interface RouteConfig<TQuery = any, TParams = any, TBody = any, TResponse
   strict?: boolean;
   /** Per-route response validation override */
   validateResponse?: boolean;
+  /** Optional Restana middlewares to be executed before validation */
+  middlewares?: RequestHandler<Protocol.HTTP>[];
   handler: (context: {
     query: TQuery;
     params: TParams;
@@ -306,7 +308,8 @@ export function createTypedApp(
 
     // Register the route with Restana
     const handler = createValidatedHandler(config);
-    (restanaApp as any)[method](path, handler);
+    const middlewares = config.middlewares ?? [];
+    (restanaApp as any)[method](path, ...middlewares, handler);
   }
 
   // Create the typed app object

--- a/tests/core/route-middlewares.test.ts
+++ b/tests/core/route-middlewares.test.ts
@@ -1,0 +1,100 @@
+import request from 'supertest';
+import { z } from 'zod';
+import { TypeSafeApp } from '../../src/core/schema-types';
+import { createTestApp } from '../test-utils';
+
+describe('Route middlewares', () => {
+  let app: TypeSafeApp;
+  let server: any;
+
+  beforeEach(() => {
+    app = createTestApp();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+  });
+
+  test('should execute middlewares before validation and modify req/res', async () => {
+    const QuerySchema = z.object({
+      token: z.string()
+    });
+
+    const mw = (req: any, res: any, next: any) => {
+      req.query.token = 'from-middleware';
+      (req as any).fromMw = true;
+      res.setHeader('x-middleware', 'yes');
+      next();
+    };
+
+    app.get('/with-mw', {
+      schema: { query: QuerySchema },
+      middlewares: [mw],
+      handler: async ({ query, req }) => {
+        return {
+          token: query.token,
+          fromMw: (req as any).fromMw
+        };
+      }
+    });
+
+    server = await app.start(0);
+    const port = server.address().port;
+
+    const res = await request(`http://localhost:${port}`)
+      .get('/with-mw')
+      .expect(200);
+
+    expect(res.headers['x-middleware']).toBe('yes');
+    expect(res.body).toEqual({ token: 'from-middleware', fromMw: true });
+  });
+
+  test('should apply middlewares only to configured routes', async () => {
+    const QuerySchema = z.object({
+      token: z.string()
+    });
+
+    const mw = (req: any, res: any, next: any) => {
+      req.query.token = 'from-middleware';
+      res.setHeader('x-middleware', 'yes');
+      next();
+    };
+
+    app.get('/with-mw', {
+      schema: { query: QuerySchema },
+      middlewares: [mw],
+      handler: async ({ query }) => ({ token: query.token })
+    });
+
+    app.get('/without-mw', {
+      schema: { query: QuerySchema },
+      handler: async ({ query }) => ({ token: query.token })
+    });
+
+    server = await app.start(0);
+    const port = server.address().port;
+
+    // Route without middleware should fail validation when token is missing
+    await request(`http://localhost:${port}`)
+      .get('/without-mw')
+      .expect(400);
+
+    // Route with middleware should inject token and set header
+    const withMwRes = await request(`http://localhost:${port}`)
+      .get('/with-mw')
+      .expect(200);
+    expect(withMwRes.headers['x-middleware']).toBe('yes');
+    expect(withMwRes.body).toEqual({ token: 'from-middleware' });
+
+    // Route without middleware succeeds when token provided but header is absent
+    const withoutMwRes = await request(`http://localhost:${port}`)
+      .get('/without-mw?token=client')
+      .expect(200);
+    expect(withoutMwRes.headers['x-middleware']).toBeUndefined();
+    expect(withoutMwRes.body).toEqual({ token: 'client' });
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow defining Restana middlewares on typed routes
- ensure middlewares run before validation when registering routes
- test middleware behavior and scoping

## Testing
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d2ea02b4c832cab4f744c437e754d